### PR TITLE
Replace distance filtering with city dropdown selection

### DIFF
--- a/assets/css/all-restaurants.css
+++ b/assets/css/all-restaurants.css
@@ -495,23 +495,6 @@
     flex-shrink: 0;
 }
 
-/* Distance Options */
-.distance-options {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
-
-.distance-option {
-    opacity: 0.5;
-    pointer-events: none;
-}
-
-.distance-option.enabled {
-    opacity: 1;
-    pointer-events: auto;
-}
-
 /* Price Range Inputs */
 .price-range-slider {
     margin-bottom: 16px;
@@ -2212,11 +2195,6 @@
 .price-display {
     color: var(--primary-color);
     font-weight: 600;
-}
-
-.distance-display {
-    color: var(--text-secondary);
-    font-weight: 500;
 }
 
 .rating-bubble.half {

--- a/assets/js/single-restaurant-map.js
+++ b/assets/js/single-restaurant-map.js
@@ -81,11 +81,10 @@
     function initializeFilters() {
         // Search input
         $('#restaurant-search').on('input', debounce(handleFilterChange, 300));
-        
+
         // Filter dropdowns and inputs
-        $('#city-filter').on('input', debounce(handleFilterChange, 300));
+        $('#city-filter').on('change', handleFilterChange);
         $('#cuisine-filter').on('change', handleFilterChange);
-        $('#distance-filter').on('change', handleFilterChange);
         
         // Sort dropdown
         $('#sort-restaurants').on('change', handleSortChange);
@@ -119,13 +118,6 @@
             currentFilters.cuisine = cuisineFilter;
         }
 
-        const distanceFilter = $('#distance-filter').val();
-        if (distanceFilter && window.userLocation) {
-            currentFilters.distance = distanceFilter;
-            currentFilters.lat = window.userLocation.lat;
-            currentFilters.lng = window.userLocation.lng;
-        }
-
         // Apply filters and reload
         loadAllRestaurants(currentFilters);
     }
@@ -148,7 +140,6 @@
         $('#restaurant-search').val('');
         $('#city-filter').val('');
         $('#cuisine-filter').val('');
-        $('#distance-filter').val('');
         $('#sort-restaurants').val('featured');
         
         currentFilters = {};
@@ -350,14 +341,6 @@
             content += `</p>`;
         }
 
-        // Distance
-        if (restaurant.distance) {
-            content += `<p style="margin: 0 0 8px 0; font-size: 13px; color: #059669; display: flex; align-items: center; gap: 6px;">`;
-            content += `<i class="fas fa-route" style="width: 12px; color: #059669;"></i>`;
-            content += `${restaurant.distance} km de distance`;
-            content += `</p>`;
-        }
-
         // View details button
         content += `<div style="margin-top: 8px;">`;
         if (isCurrentRestaurant) {
@@ -460,7 +443,7 @@
                         
                         ${meta.city ? `<p class="text-sm text-gray-600 mb-1"><i class="fas fa-map-marker-alt mr-1"></i>${escapeHtml(meta.city)}</p>` : ''}
                         ${meta.cuisine_type ? `<p class="text-sm text-gray-600 mb-2"><i class="fas fa-utensils mr-1"></i>${escapeHtml(meta.cuisine_type.charAt(0).toUpperCase() + meta.cuisine_type.slice(1))}</p>` : ''}
-                        ${restaurant.distance ? `<p class="text-sm text-green-600 mb-2"><i class="fas fa-route mr-1"></i>${restaurant.distance} km de distance</p>` : ''}
+                        
                         
                         <div class="flex items-center space-x-2 mt-3">
                             <a href="${restaurant.link}" class="flex-1 px-3 py-2 bg-yellow-400 hover:bg-yellow-500 text-gray-800 text-sm font-medium rounded transition duration-200 text-center">

--- a/assets/js/single-restaurant.js
+++ b/assets/js/single-restaurant.js
@@ -57,9 +57,6 @@
         // Initialize filters
         initializeFilters();
         
-        // Initialize location detection
-        initializeLocationDetection();
-        
         // Load all restaurants
         loadAllRestaurants();
         
@@ -119,9 +116,8 @@
     function initializeFilters() {
         // Desktop filter elements
         $('#restaurant-name-filter').on('input', debounce(handleFilterChange, 500));
-        $('#city-filter').on('input', debounce(handleFilterChange, 500));
+        $('#city-filter').on('change', handleFilterChange);
         $('#cuisine-filter').on('change', handleFilterChange);
-        $('#distance-filter').on('change', handleFilterChange);
         $('#featured-only').on('change', handleFilterChange);
         $('#sort-restaurants').on('change', handleSortChange);
         $('#search-restaurants').on('click', handleFilterChange);
@@ -171,7 +167,6 @@
         const mobileRestaurantName = document.getElementById('mobile-restaurant-name');
         const mobileCity = document.getElementById('mobile-city');
         const mobileCuisine = document.getElementById('mobile-cuisine');
-        const mobileDistance = document.getElementById('mobile-distance');
         const mobileSort = document.getElementById('mobile-sort');
         const mobileFeaturedOnly = document.getElementById('mobile-featured-only');
         
@@ -180,17 +175,12 @@
             mobileRestaurantName.addEventListener('input', debounce(handleMobileFilterChange, 500));
         }
         if (mobileCity) {
-            mobileCity.addEventListener('input', debounce(handleMobileFilterChange, 500));
+            mobileCity.addEventListener('change', handleMobileFilterChange);
         }
-        
+
         // Mobile filter immediate changes
         if (mobileCuisine) {
             mobileCuisine.addEventListener('change', handleMobileFilterChange);
-        }
-        if (mobileDistance) {
-            mobileDistance.addEventListener('change', function() {
-                handleMobileFilterChange();
-            });
         }
         if (mobileSort) {
             mobileSort.addEventListener('change', handleMobileSortChange);
@@ -272,7 +262,6 @@
         const mobileRestaurantName = document.getElementById('mobile-restaurant-name');
         const mobileCity = document.getElementById('mobile-city');
         const mobileCuisine = document.getElementById('mobile-cuisine');
-        const mobileDistance = document.getElementById('mobile-distance');
         const mobileFeaturedOnly = document.getElementById('mobile-featured-only');
         
         
@@ -295,13 +284,6 @@
             const desktopCuisine = document.getElementById('cuisine-filter');
             if (desktopCuisine) {
                 desktopCuisine.value = mobileCuisine.value;
-            }
-        }
-        
-        if (mobileDistance) {
-            const desktopDistance = document.getElementById('distance-filter');
-            if (desktopDistance) {
-                desktopDistance.value = mobileDistance.value;
             }
         }
         
@@ -338,55 +320,18 @@
         const mobileRestaurantName = document.getElementById('mobile-restaurant-name');
         const mobileCity = document.getElementById('mobile-city');
         const mobileCuisine = document.getElementById('mobile-cuisine');
-        const mobileDistance = document.getElementById('mobile-distance');
         const mobileSort = document.getElementById('mobile-sort');
         const mobileFeaturedOnly = document.getElementById('mobile-featured-only');
-        
+
         if (mobileRestaurantName) mobileRestaurantName.value = '';
         if (mobileCity) mobileCity.value = '';
         if (mobileCuisine) mobileCuisine.value = '';
-        if (mobileDistance) mobileDistance.value = '';
         if (mobileSort) mobileSort.value = 'featured';
         if (mobileFeaturedOnly) mobileFeaturedOnly.checked = false;
         
         
         // Clear desktop filters too
         clearAllFilters();
-    }
-
-    /**
-     * Initialize location detection for distance filtering
-     */
-    function initializeLocationDetection() {
-        if (navigator.geolocation) {
-            navigator.geolocation.getCurrentPosition(
-                function(position) {
-                    window.userLocation = {
-                        lat: position.coords.latitude,
-                        lng: position.coords.longitude
-                    };
-                    
-                    // Enable distance filter
-                    $('#distance-filter').prop('disabled', false);
-                    
-                    // Enable mobile distance filter
-                    const mobileDistance = document.getElementById('mobile-distance');
-                    if (mobileDistance) {
-                        mobileDistance.disabled = false;
-                    }
-                    
-                },
-                function(error) {
-                    $('#distance-filter').prop('disabled', true);
-                    
-                    // Disable mobile distance filter
-                    const mobileDistance = document.getElementById('mobile-distance');
-                    if (mobileDistance) {
-                        mobileDistance.disabled = true;
-                    }
-                }
-            );
-        }
     }
 
     /**
@@ -414,7 +359,6 @@
         $('#restaurant-name-filter').val('');
         $('#city-filter').val('');
         $('#cuisine-filter').val('');
-        $('#distance-filter').val('');
         $('#featured-only').prop('checked', false);
         $('#sort-restaurants').val('featured');
         
@@ -445,14 +389,6 @@
         const cuisine = $('#cuisine-filter').val();
         if (cuisine) {
             currentFilters.cuisine = cuisine;
-        }
-
-        // Distance (only if location is available)
-        const distance = $('#distance-filter').val();
-        if (distance && window.userLocation) {
-            currentFilters.distance = distance;
-            currentFilters.lat = window.userLocation.lat;
-            currentFilters.lng = window.userLocation.lng;
         }
 
         // Featured only

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -361,30 +361,6 @@ class LeBonResto_Admin {
         );
         
         add_settings_field(
-            'default_radius',
-            __('Default Search Radius', 'le-bon-resto'),
-            array($this, 'setting_field_default_radius'),
-            'lebonresto_settings',
-            'lebonresto_general'
-        );
-        
-        add_settings_field(
-            'max_radius',
-            __('Maximum Search Radius', 'le-bon-resto'),
-            array($this, 'setting_field_max_radius'),
-            'lebonresto_settings',
-            'lebonresto_general'
-        );
-        
-        add_settings_field(
-            'distance_filter_options',
-            __('Distance Filter Options', 'le-bon-resto'),
-            array($this, 'setting_field_distance'),
-            'lebonresto_settings',
-            'lebonresto_general'
-        );
-        
-        add_settings_field(
             'enable_layer_switcher',
             __('Enable Map Layer Switcher', 'le-bon-resto'),
             array($this, 'setting_field_layer_switcher'),
@@ -457,9 +433,6 @@ class LeBonResto_Admin {
             'default_map_center_lat' => '48.8566',
             'default_map_center_lng' => '2.3522',
             'default_zoom_level' => '12',
-            'default_radius' => '25',
-            'max_radius' => '100',
-            'distance_filter_options' => '10,25,50,100',
             'enable_layer_switcher' => '1',
             'enable_fullscreen' => '1',
             'primary_color' => '#fedc00',
@@ -503,24 +476,6 @@ class LeBonResto_Admin {
         $options = $this->get_options();
         echo '<input type="number" min="1" max="18" name="lebonresto_options[default_zoom_level]" value="' . esc_attr($options['default_zoom_level']) . '" />';
         echo '<p class="description">' . __('Default zoom level for the map (1-18, where 18 is closest)', 'le-bon-resto') . '</p>';
-    }
-    
-    public function setting_field_default_radius() {
-        $options = $this->get_options();
-        echo '<input type="number" min="1" max="1000" name="lebonresto_options[default_radius]" value="' . esc_attr($options['default_radius']) . '" />';
-        echo '<p class="description">' . __('Default search radius in kilometers when the map loads', 'le-bon-resto') . '</p>';
-    }
-    
-    public function setting_field_max_radius() {
-        $options = $this->get_options();
-        echo '<input type="number" min="1" max="1000" name="lebonresto_options[max_radius]" value="' . esc_attr($options['max_radius']) . '" />';
-        echo '<p class="description">' . __('Maximum search radius allowed in the radius slider', 'le-bon-resto') . '</p>';
-    }
-    
-    public function setting_field_distance() {
-        $options = $this->get_options();
-        echo '<input type="text" name="lebonresto_options[distance_filter_options]" value="' . esc_attr($options['distance_filter_options']) . '" />';
-        echo '<p class="description">' . __('Comma-separated list of distance options in kilometers (e.g., 10,25,50,100)', 'le-bon-resto') . '</p>';
     }
     
     public function setting_field_layer_switcher() {
@@ -652,45 +607,12 @@ class LeBonResto_Admin {
             }
         }
         
-        // Validate default radius
-        if (isset($input['default_radius'])) {
-            $radius = intval($input['default_radius']);
-            if ($radius >= 1 && $radius <= 1000) {
-                $validated['default_radius'] = $radius;
-            }
-        }
-        
-        // Validate max radius
-        if (isset($input['max_radius'])) {
-            $max_radius = intval($input['max_radius']);
-            if ($max_radius >= 1 && $max_radius <= 1000) {
-                $validated['max_radius'] = $max_radius;
-            }
-        }
-        
         // Validate layer switcher
         $validated['enable_layer_switcher'] = isset($input['enable_layer_switcher']) ? '1' : '0';
-        
+
         // Validate fullscreen
         $validated['enable_fullscreen'] = isset($input['enable_fullscreen']) ? '1' : '0';
-        
-        // Validate distance options
-        if (isset($input['distance_filter_options'])) {
-            $distances = sanitize_text_field($input['distance_filter_options']);
-            // Validate that it's a comma-separated list of numbers
-            $distance_array = explode(',', $distances);
-            $valid_distances = array();
-            foreach ($distance_array as $distance) {
-                $distance = trim($distance);
-                if (is_numeric($distance) && $distance > 0) {
-                    $valid_distances[] = intval($distance);
-                }
-            }
-            if (!empty($valid_distances)) {
-                $validated['distance_filter_options'] = implode(',', $valid_distances);
-            }
-        }
-        
+
         // Validate color
         if (isset($input['primary_color'])) {
             $color = sanitize_hex_color($input['primary_color']);

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -46,6 +46,8 @@ function lebonresto_all_restaurants_page_shortcode($atts) {
             true
         );
 
+    $restaurant_cities = function_exists('lebonresto_get_restaurant_cities') ? lebonresto_get_restaurant_cities() : array();
+
     // Start output buffering
     ob_start();
     
@@ -133,12 +135,15 @@ function lebonresto_map_page_shortcode($atts) {
                         
                     <!-- City Filter -->
                     <div class="w-full lg:w-48">
-                            <input 
-                                type="text" 
-                                id="city-filter" 
-                            placeholder="<?php _e('City...', 'le-bon-resto'); ?>"
+                            <select
+                                id="city-filter"
                             class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-transparent"
-                            />
+                            >
+                                <option value=""><?php _e('All Cities', 'le-bon-resto'); ?></option>
+                                <?php foreach ($restaurant_cities as $city_option): ?>
+                                    <option value="<?php echo esc_attr($city_option); ?>"><?php echo esc_html($city_option); ?></option>
+                                <?php endforeach; ?>
+                            </select>
                         </div>
                         
                     <!-- Cuisine Filter -->


### PR DESCRIPTION
## Summary
- replace manual city inputs with dropdowns filled from unique restaurant cities across public views
- remove distance-based filtering, sorting, and settings from the API, admin UI, and front-end scripts
- streamline client logic for city-based filtering on all listings and map components while cleaning up unused distance styles

## Testing
- php -l includes/api.php
- php -l includes/admin.php
- php -l includes/shortcodes.php
- php -l templates/all-restaurants.php
- php -l templates/single-restaurant.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914bd4b49b88324921b80fff919b0d8)